### PR TITLE
Fix overflow in printint

### DIFF
--- a/kernel/printf.c
+++ b/kernel/printf.c
@@ -32,10 +32,13 @@ printint(int xx, int base, int sign)
   int i;
   uint x;
 
-  if(sign && (sign = xx < 0))
-    x = -xx;
-  else
+  if(sign && xx < 0){
+    x = -(uint)xx;
+    sign = 1;
+  } else {
     x = xx;
+    sign = 0;
+  }
 
   i = 0;
   do {

--- a/user/printf.c
+++ b/user/printf.c
@@ -22,7 +22,7 @@ printint(int fd, int xx, int base, int sgn)
   neg = 0;
   if(sgn && xx < 0){
     neg = 1;
-    x = -xx;
+    x = -(uint)xx;
   } else {
     x = xx;
   }


### PR DESCRIPTION
## Summary
- prevent undefined behavior when printing INT_MIN

## Testing
- `make TOOLPREFIX=aarch64-linux-gnu-`

------
https://chatgpt.com/codex/tasks/task_e_683faca68b7c8333a6351adc3c47ebdf